### PR TITLE
miscellaneos + 'tenantRef' changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ This will:
 - Install the minio operator
 - Create a minio tenant
 - Apply the [custom resources](./manifests/crds.yaml)
+- Apply the [example resources](./manifests/example_resources.yaml)
+- Set a rule in /etc/hosts for the internal service name of the minio tenant
+- Waits for minio tenant to finish deploying
+- Forward the minio tenant service to localhost
 
 ### Creating a launch script
 

--- a/dev.template.py
+++ b/dev.template.py
@@ -1,6 +1,7 @@
 import asyncio
 import pathlib
 
+from minio_operator_ext.logs import configure_logging
 from minio_operator_ext.operator import Operator
 
 

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -17,8 +17,13 @@ spec:
               properties:
                 name:
                   type: string
-                tenant:
-                  type: string
+                tenantRef:
+                  type: object
+                  properties:
+                    namespace:
+                      type: string
+                    name:
+                      type: string
             status:
               type: object
               properties:
@@ -26,10 +31,14 @@ spec:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
       additionalPrinterColumns:
-        - name: Tenant
+        - name: Tenant Namespace
           type: string
-          description: Tenant
-          jsonPath: .status.currentSpec.tenant
+          description: Tenant Namespace
+          jsonPath: .status.currentSpec.tenantRef.namespace
+        - name: Tenant Name
+          type: string
+          description: Tenant Name
+          jsonPath: .status.currentSpec.tenantRef.name
         - name: Name
           type: string
           description: Name
@@ -68,8 +77,13 @@ spec:
                       type: string
                     key:
                       type: string
-                tenant:
-                  type: string
+                tenantRef:
+                  type: object
+                  properties:
+                    namespace:
+                      type: string
+                    name:
+                      type: string
             status:
               type: object
               properties:
@@ -77,10 +91,14 @@ spec:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
       additionalPrinterColumns:
-        - name: Tenant
+        - name: Tenant Namespace
           type: string
-          description: Tenant
-          jsonPath: .status.currentSpec.tenant
+          description: Tenant Namespace
+          jsonPath: .status.currentSpec.tenantRef.namespace
+        - name: Tenant Name
+          type: string
+          description: Tenant Name
+          jsonPath: .status.currentSpec.tenantRef.name
         - name: Access Key
           type: string
           description: Access Key
@@ -110,8 +128,13 @@ spec:
               properties:
                 name:
                   type: string
-                tenant:
-                  type: string
+                tenantRef:
+                  type: object
+                  properties:
+                    namespace:
+                      type: string
+                    name:
+                      type: string
                 version:
                   type: string
                   default: "2012-10-17"
@@ -137,10 +160,14 @@ spec:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
       additionalPrinterColumns:
-        - name: Tenant
+        - name: Tenant Namespace
           type: string
-          description: Tenant
-          jsonPath: .status.currentSpec.tenant
+          description: Tenant Namespace
+          jsonPath: .status.currentSpec.tenantRef.namespace
+        - name: Tenant Name
+          type: string
+          description: Tenant Name
+          jsonPath: .status.currentSpec.tenantRef.name
         - name: Name
           type: string
           description: Name
@@ -168,8 +195,13 @@ spec:
             spec:
               type: object
               properties:
-                tenant:
-                  type: string
+                tenantRef:
+                  type: object
+                  properties:
+                    namespace:
+                      type: string
+                    name:
+                      type: string
                 policy:
                   type: string
                 user:
@@ -181,10 +213,14 @@ spec:
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
       additionalPrinterColumns:
-        - name: Tenant
+        - name: Tenant Namespace
           type: string
-          description: Tenant
-          jsonPath: .status.currentSpec.tenant
+          description: Tenant Namespace
+          jsonPath: .status.currentSpec.tenantRef.namespace
+        - name: Tenant Name
+          type: string
+          description: Tenant Name
+          jsonPath: .status.currentSpec.tenantRef.name
         - name: Policy
           type: string
           description: Policy

--- a/manifests/example_resources.yaml
+++ b/manifests/example_resources.yaml
@@ -4,7 +4,9 @@ metadata:
   name: test
 spec:
   name: test
-  tenant: minio-tenant/myminio
+  tenantRef:
+    namespace: minio-tenant
+    name: myminio
 ---
 apiVersion: v1
 kind: Secret
@@ -22,7 +24,9 @@ spec:
   secretKeyRef:
     name: user
     key: secretKey
-  tenant: minio-tenant/myminio
+  tenantRef:
+    namespace: minio-tenant
+    name: myminio
 ---
 apiVersion: bfiola.dev/v1
 kind: MinioPolicy
@@ -30,7 +34,6 @@ metadata:
   name: test
 spec:
   name: test
-  tenant: minio-tenant/myminio
   statement:
     - effect: "Allow"
       action:
@@ -48,6 +51,9 @@ spec:
         - "s3:ListBucketMultipartUploads"
       resource:
         - "arn:aws:s3:::test"
+  tenantRef:
+    namespace: minio-tenant
+    name: myminio
 ---
 apiVersion: bfiola.dev/v1
 kind: MinioPolicyBinding
@@ -55,5 +61,7 @@ metadata:
   name: test
 spec:
   policy: test
+  tenantRef:
+    namespace: minio-tenant
+    name: myminio
   user: test
-  tenant: minio-tenant/myminio

--- a/test.yaml
+++ b/test.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: user2
-stringData:
-  secretKey: password


### PR DESCRIPTION
- Remove endpoint overrides
- Replace 'tenant' string property with 'tenantRef' object property in custom resources
- Resolve tenant during spec resolution
- Remove tenant argument from all minio client/minio admin client crud operations (- the tenant is a member of the model)
- Remove get_tenant calls from operator crud methods (- the tenant is fetched during spec resolution)
- Rename ResourceRef -> SpecResourceRef, define ResourceRef as a reference with a known namespace
- Modify all resource helper functions to use ResourceRef arguments
- Update example manifests
- Update immutable field references in update operations to point to 'tenantRef'
- Rename scripts/dev-cluster.sh to scripts/dev.sh
- Add port-forwarding and /etc/hosts modification to dev scripts
- Update dev.template.py to set logging level
- Change order of hook decorators to capture retryability of errors in log_hook method