### PR TITLE
fix: support ldap policy bindings

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -77,3 +77,22 @@ RUN apt -y install curl && \
     tar xvzf k9s.tar.gz && \
     rm -rf k9s.tar.gz
 ENV PATH="/opt/k9s:${PATH}"
+
+# install kubefwd
+RUN apt -y install curl && \
+    mkdir -p /opt/kubefwd && \
+    cd /opt/kubefwd && \
+    curl -fsSL -o kubefwd.tar.gz "https://github.com/txn2/kubefwd/releases/download/1.22.5/kubefwd_Linux_${TARGETARCH}.tar.gz" && \
+    tar xvzf kubefwd.tar.gz && \
+    rm -rf kubefwd.tar.gz
+ENV PATH="/opt/kubefwd:${PATH}"
+
+# install mc
+RUN apt -y install curl && \
+    mkdir -p /opt/mc && \
+    cd /opt/mc && \
+    curl -fsSL -o mc "https://dl.min.io/client/mc/release/linux-${TARGETARCH}/mc" && \
+    chmod +x mc
+ENV MC_DISABLE_PAGER=1
+ENV MC_INSECURE=1
+ENV PATH="/opt/mc:${PATH}"

--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ I personally use [vscode](https://code.visualstudio.com/) as an IDE. For a consi
 
 NOTE: Helper scripts are written under the assumption that they're being executed within a dev container.
 
-### Creating a cluster
+### Creating a development environment
 
 From the project root, run the following to create a development cluster to test the operator with:
 
 ```shell
 cd /workspaces/minio-operator-ext
-./scripts/dev.sh
+./dev/create-cluster.sh
 ```
 
 This will:
@@ -66,15 +66,26 @@ This will:
 - Create a new dev cluster
 - Install the minio operator
 - Create a minio tenant
+- Deploy an ldap server
 - Apply the [custom resources](./manifests/crds.yaml)
 - Apply the [example resources](./manifests/example-resources.yaml)
-- Set a rule in /etc/hosts for the internal service name of the minio tenant
 - Waits for minio tenant to finish deploying
-- Forward the minio tenant service to localhost
+- Forward all services locally under their cluster-local DNS names
+
+### Testing LDAP identities
+
+After creating a local development cluster, you can configure minio to use the deployed LDAP server as its identity provider:
+
+```shell
+cd /workspaces/minio-operator-ext
+./dev/use-ldap.sh
+```
+
+NOTE: With an identity provider configured, attempts to operate on builtin identities will fail.
 
 ### Creating a launch script
 
-Copy the [dev.template.py](./dev.template.py) script to `dev.py`, then run it to start the operator.
+Copy the [dev.template.py](./dev.template.py) script to `dev.py`, then run it to start the operator against the local development environment.
 
 If placed in the top-level directory, `dev.py` is gitignored and you can change this file as needed without worrying about committing it to git.
 

--- a/dev/forward-ports.sh
+++ b/dev/forward-ports.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -e
+# starts kubefwd in the background
+log="/var/log/port-forward.log"
+
+echo "killing kubefwd"
+pkill kubefwd || true
+
+echo "starting kubefwd in background"
+nohup kubefwd svc --all-namespaces >> "${log}" &

--- a/dev/openldap.yaml
+++ b/dev/openldap.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openldap
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openldap
+  namespace: openldap
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openldap
+  template:
+    metadata:
+      labels:
+        app: openldap
+    spec:
+      containers:
+        - image: docker.io/bitnami/openldap:latest
+          name: openldap
+          env:
+            - name: LDAP_ADMIN_USERNAME
+              value: ldap-admin
+            - name: LDAP_ADMIN_PASSWORD
+              value: ldap-admin
+            - name: LDAP_USERS
+              value: ldap-user1,ldap-user2
+            - name: LDAP_PASSWORDS
+              value: ldap-user1,ldap-user2
+            - name: LDAP_GROUP
+              value: ldap-group
+            - name: LDAP_ROOT
+              value: dc=example,dc=org
+            - name: LDAP_ADMIN_DN
+              value: cn=admin,dc=example,dc=org
+            - name: LDAP_LOGLEVEL
+              value: "1"
+          ports:
+            - containerPort: 1389
+            - containerPort: 1636
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: openldap
+  namespace: openldap
+spec:
+  selector:
+    app: openldap
+  ports:
+    - name: unencrypted
+      protocol: TCP
+      port: 389
+      targetPort: 1389
+    - name: encrypted
+      protocol: TCP
+      port: 636
+      targetPort: 1389

--- a/dev/use-ldap.sh
+++ b/dev/use-ldap.sh
@@ -1,0 +1,15 @@
+#!/bin/sh -e
+# configures the development minio tenant with a local ldap server
+echo "adding ldap server"
+mc idp ldap add local \
+    server_addr=openldap.openldap.svc:389 \
+    lookup_bind_dn=cn='ldap-admin,dc=example,dc=org' \
+    lookup_bind_password=ldap-admin \
+    user_dn_search_base_dn='ou=users,dc=example,dc=org' \
+    user_dn_search_filter='(&(objectClass=posixAccount)(uid=%s))' \
+    group_search_base_dn='ou=users,dc=example,dc=org' \
+    group_search_filter='(&(objectClass=groupOfNames)(member=%d))' \
+    server_insecure=on
+
+echo "restarting tenant"
+mc admin service restart local

--- a/manifests/crds.yaml
+++ b/manifests/crds.yaml
@@ -313,9 +313,19 @@ spec:
                 policy:
                   type: string
                 user:
-                  type: string
+                  type: object
+                  properties:
+                    builtin:
+                      type: string
+                    ldap:
+                      type: string
                 group:
-                  type: string
+                  type: object
+                  properties:
+                    builtin:
+                      type: string
+                    ldap:
+                      type: string
             status:
               type: object
               properties:

--- a/manifests/example-resources.yaml
+++ b/manifests/example-resources.yaml
@@ -11,18 +11,18 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: user
+  name: builtin-user
 stringData:
   secretKey: password
 ---
 apiVersion: bfiola.dev/v1
 kind: MinioUser
 metadata:
-  name: user
+  name: builtin-user
 spec:
-  accessKey: user
+  accessKey: builtin-user
   secretKeyRef:
-    name: user
+    name: builtin-user
     key: secretKey
   tenantRef:
     namespace: minio-tenant
@@ -31,9 +31,9 @@ spec:
 apiVersion: bfiola.dev/v1
 kind: MinioGroup
 metadata:
-  name: group
+  name: builtin-group
 spec:
-  name: group
+  name: builtin-group
   tenantRef:
     namespace: minio-tenant
     name: myminio
@@ -41,13 +41,13 @@ spec:
 apiVersion: bfiola.dev/v1
 kind: MinioGroupBinding
 metadata:
-  name: user-to-group
+  name: builtin-user-to-builtin-group
 spec:
-  group: group
+  group: builtin-group
   tenantRef:
     namespace: minio-tenant
     name: myminio
-  user: user
+  user: builtin-user
 ---
 apiVersion: bfiola.dev/v1
 kind: MinioPolicy
@@ -79,20 +79,46 @@ spec:
 apiVersion: bfiola.dev/v1
 kind: MinioPolicyBinding
 metadata:
-  name: user-to-policy
+  name: builtin-user-to-policy
 spec:
   policy: policy
   tenantRef:
     namespace: minio-tenant
     name: myminio
-  user: user
+  user:
+    builtin: builtin-user
 ---
 apiVersion: bfiola.dev/v1
 kind: MinioPolicyBinding
 metadata:
-  name: group-to-policy
+  name: builtin-group-to-policy
 spec:
-  group: group
+  group:
+    builtin: builtin-group
+  policy: policy
+  tenantRef:
+    namespace: minio-tenant
+    name: myminio
+---
+apiVersion: bfiola.dev/v1
+kind: MinioPolicyBinding
+metadata:
+  name: ldap-user-to-policy
+spec:
+  policy: policy
+  tenantRef:
+    namespace: minio-tenant
+    name: myminio
+  user:
+    ldap: ldap-user1
+---
+apiVersion: bfiola.dev/v1
+kind: MinioPolicyBinding
+metadata:
+  name: ldap-group-to-policy
+spec:
+  group:
+    ldap: "cn=ldap-group,ou=users,dc=example,dc=org"
   policy: policy
   tenantRef:
     namespace: minio-tenant

--- a/minio_operator_ext/clients.py
+++ b/minio_operator_ext/clients.py
@@ -1,0 +1,101 @@
+import dataclasses
+import json
+from typing import cast
+
+import minio
+import minio.crypto
+
+
+@dataclasses.dataclass
+class FakeEnum:
+    """
+    The minio client refers to API endpoints via an enum.
+
+    Because the client in this package extends the minio client with support for additional enpdoints
+    that currently aren't available upstream - this class presents an object that 'looks' like an enum
+    (i.e., has a 'value' field).
+    """
+
+    value: str
+
+
+class Minio(minio.Minio):
+    """
+    Subclass of the base minio client.
+    """
+
+    pass
+
+
+class MinioAdmin(minio.MinioAdmin):
+    """
+    Subclass of the base minio admin client
+    """
+
+    def ldap_policy_set(
+        self,
+        policy_name: str | list[str],
+        user: str | None = None,
+        group: str | None = None,
+    ) -> str:
+        """
+        Implements idp/ldap/policy/attach.  Roughly copies the implementation of 'policy_unset'.
+
+        NOTE: the minio-py client is not up to date: https://github.com/minio/minio-py/issues/1337
+        """
+        if (user is not None) ^ (group is not None):
+            policies = policy_name if isinstance(policy_name, list) else [policy_name]
+            data: dict[str, str | list[str]] = {"policies": policies}
+            if user:
+                data["user"] = user
+            if group:
+                data["group"] = group
+            response = self._url_open(
+                "POST",
+                FakeEnum(value="idp/ldap/policy/attach"),
+                body=minio.crypto.encrypt(
+                    json.dumps(data).encode(),
+                    self._provider.retrieve().secret_key,
+                ),
+                preload_content=False,
+            )
+            plain_data = minio.crypto.decrypt(
+                response,
+                self._provider.retrieve().secret_key,
+            )
+            return plain_data.decode()
+        raise ValueError("either user or group must be set")
+
+    def ldap_policy_unset(
+        self,
+        policy_name: str | list[str],
+        user: str | None = None,
+        group: str | None = None,
+    ) -> str:
+        """
+        Implements idp/ldap/policy/detach.  Copies the implementation of 'policy_unset'.
+
+        NOTE: the minio-py client is not up to date: https://github.com/minio/minio-py/issues/1337
+        """
+        if (user is not None) ^ (group is not None):
+            policies = policy_name if isinstance(policy_name, list) else [policy_name]
+            data: dict[str, str | list[str]] = {"policies": policies}
+            if user:
+                data["user"] = user
+            if group:
+                data["group"] = group
+            response = self._url_open(
+                "POST",
+                FakeEnum(value="idp/ldap/policy/detach"),
+                body=minio.crypto.encrypt(
+                    json.dumps(data).encode(),
+                    self._provider.retrieve().secret_key,
+                ),
+                preload_content=False,
+            )
+            plain_data = minio.crypto.decrypt(
+                response,
+                self._provider.retrieve().secret_key,
+            )
+            return plain_data.decode()
+        raise ValueError("either user or group must be set")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 dependencies = [
     "click",
     "minio",
-    "bfiola-operator-core==2.0.0",
+    "bfiola-operator-core==2.0.1",
     "python-dotenv",
 ]
 


### PR DESCRIPTION
- update dependency on operator-core to 2.0.1
- add support for builtin/ldap identities within crds and operator
- update devcontainer Dockerfile to install mc and kubefwd cli tools
- implement ldap_policy_attach/ldap_policy_detach operations in custom minio client subclasses
- update dev workflow to create local ldap server for testing and forward all services
- update example resources to include user/group ldap policy bindings