### PR TITLE
feat: external cert support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,18 +51,18 @@ The following arguments/environment variables configure the operator:
 
 The operator requires the a service account with the following RBAC settings:
 
-| Resource                         | Verbs                    | Why                                                                                                                 |
-| -------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------- |
-| minio.min.io/v2/Tenant           | Get                      | Used to discover MinIO tenants                                                                                      |
-| v1/ConfigMap                     | Get                      | Used to obtain the CA bundle used to generate a MinIO tenant's TLS certificates (- for HTTP client cert validation) |
-| v1/Secret                        | Get                      | Used to fetch a MinIO tenant's configuration (which is stored as a secret)                                          |
-| v1/Services                      | Get                      | Used to determine a MinIO tenant's internal endpoint                                                                |
-| bfiola.dev/v1/MinioBucket        | Get, Watch, List, Update | Required for the operator to manage minio bucket resources                                                          |
-| bfiola.dev/v1/MinioGroup         | Get, Watch, List, Update | Required for the operator to manage minio group resources                                                           |
-| bfiola.dev/v1/MinioGroupBinding  | Get, Watch, List, Update | Required for the operator to manage minio group membership                                                          |
-| bfiola.dev/v1/MinioPolicy        | Get, Watch, List, Update | Required for the operator to manage minio policies                                                                  |
-| bfiola.dev/v1/MinioPolicyBinding | Get, Watch, List, Update | Required for the operator to manage minio policy attachments                                                        |
-| bfiola.dev/v1/MinioUser          | Get, Watch, List, Update | Required for the operator to manage minio user resources                                                            |
+| Resource                         | Verbs                    | Why                                                                                                                                                                    |
+| -------------------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| minio.min.io/v2/Tenant           | Get                      | Used to discover MinIO tenants                                                                                                                                         |
+| v1/ConfigMap                     | Get                      | Used to fetch TLS certificate data to perform TLS verification when connecting to MinIO tenants                                                                        |
+| v1/Secret                        | Get, List                | Used to fetch a MinIO tenant's configuration (which is stored as a secret) and fetch TLS certificate data to perform TLS verification when connecting to MinIO tenants |
+| v1/Services                      | Get                      | Used to determine a MinIO tenant's internal endpoint                                                                                                                   |
+| bfiola.dev/v1/MinioBucket        | Get, Watch, List, Update | Required for the operator to manage minio bucket resources                                                                                                             |
+| bfiola.dev/v1/MinioGroup         | Get, Watch, List, Update | Required for the operator to manage minio group resources                                                                                                              |
+| bfiola.dev/v1/MinioGroupBinding  | Get, Watch, List, Update | Required for the operator to manage minio group membership                                                                                                             |
+| bfiola.dev/v1/MinioPolicy        | Get, Watch, List, Update | Required for the operator to manage minio policies                                                                                                                     |
+| bfiola.dev/v1/MinioPolicyBinding | Get, Watch, List, Update | Required for the operator to manage minio policy attachments                                                                                                           |
+| bfiola.dev/v1/MinioUser          | Get, Watch, List, Update | Required for the operator to manage minio user resources                                                                                                               |
 
 ## Limitations
 

--- a/dev/manifests/cert-manager-resources/kustomization.yaml
+++ b/dev/manifests/cert-manager-resources/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - ./root-issuer.yaml
+  - ./tenant-ca.yaml
+  - ./tenant-issuer.yaml
+  - ./tenant-cert.yaml

--- a/dev/manifests/cert-manager-resources/root-issuer.yaml
+++ b/dev/manifests/cert-manager-resources/root-issuer.yaml
@@ -1,0 +1,6 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: cm-root
+spec:
+  selfSigned: {}

--- a/dev/manifests/cert-manager-resources/tenant-ca.yaml
+++ b/dev/manifests/cert-manager-resources/tenant-ca.yaml
@@ -1,0 +1,16 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cm-tenant-ca
+spec:
+  isCA: true
+  commonName: cm-tenant
+  secretName: cm-tenant-ca-tls
+  duration: 70128h
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: cm-root
+    kind: ClusterIssuer
+    group: cert-manager.io

--- a/dev/manifests/cert-manager-resources/tenant-cert.yaml
+++ b/dev/manifests/cert-manager-resources/tenant-cert.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cm-tenant-cert
+spec:
+  dnsNames:
+    - minio.default
+    - minio.default.svc
+    - minio.default.svc.cluster.local
+    - "*.tenant-hl.default.svc.cluster.local"
+    - "*.default.svc.cluster.local"
+    - "*.tenant.minio.default.svc.cluster.local"
+  secretName: cm-tenant-tls
+  issuerRef:
+    name: cm-tenant-issuer

--- a/dev/manifests/cert-manager-resources/tenant-issuer.yaml
+++ b/dev/manifests/cert-manager-resources/tenant-issuer.yaml
@@ -1,0 +1,7 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: cm-tenant-issuer
+spec:
+  ca:
+    secretName: cm-tenant-ca-tls

--- a/dev/manifests/cert-manager/kustomization.yaml
+++ b/dev/manifests/cert-manager/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.yaml


### PR DESCRIPTION
* Add cert-manager to dev manifests
* Add cert-manager resources to dev manifests
* Deploy cert-manager as part of 'apply-manifests' Makefile target
* Generate cert-manager resources as part of 'apply-manifests' Makefile target
* Update operator 'getTenantClientInfo' to correctly set 'secure' flag based upon external cert settings
* Update operator 'getTenantClientInfo' to build cert pool with 'operator-ca-tls' prefixed secrets
* Update operator 'getTenantClientInfo' to build cert pool with tenant spec 'externalCaCertSecret' secrets