### PR TITLE
fix: correctly handle nil bucket lifecycle/versioning configurations

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,6 +16,7 @@
         "editor.defaultFormatter": "esbenp.prettier-vscode",
         "go.testFlags": ["-v", "-count=1"],
         "go.testTimeout": "300s",
+        "exp-vscode-go.testExplorer.enable": true,
         "launch": {
           "version": "0.2.0",
           "configurations": [

--- a/dev/manifests/minio-tenant/kustomization.yaml
+++ b/dev/manifests/minio-tenant/kustomization.yaml
@@ -13,6 +13,7 @@ helmCharts:
         configuration:
           name: tenant-configuration-env
         exposeServices:
+          console: true
           minio: true
         name: tenant
         pools:

--- a/internal/e2e/main_test.go
+++ b/internal/e2e/main_test.go
@@ -42,7 +42,6 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -168,7 +167,7 @@ func Setup(t testing.TB) TestData {
 	for _, r := range testObjects {
 		nr := r.DeepCopyObject().(client.Object)
 		err := k.Get(ctx, client.ObjectKeyFromObject(nr), nr)
-		if err != nil && apierrors.IsNotFound(err) {
+		if err != nil && errors.IsNotFound(err) {
 			continue
 		}
 		require.NoError(err, "fetch existing testing k8s resource")
@@ -176,7 +175,7 @@ func Setup(t testing.TB) TestData {
 		err = k.Update(ctx, nr)
 		require.NoError(err, "remove finalizers from testing k8s resource")
 		err = k.Delete(ctx, nr)
-		if err != nil && apierrors.IsNotFound(err) {
+		if err != nil && errors.IsNotFound(err) {
 			err = nil
 		}
 		require.NoError(err, "delete testing k8s resource")
@@ -454,7 +453,7 @@ func WaitForDelete(td TestData, o client.Object) {
 		if err == nil {
 			return nil
 		}
-		if apierrors.IsNotFound(err) {
+		if errors.IsNotFound(err) {
 			err = nil
 		}
 		td.Require.NoError(err, "fetch object while waiting for object to be deleted")
@@ -771,7 +770,32 @@ func TestMinioBucket(t *testing.T) {
 		td.Require.True(vc.Enabled())
 	})
 
-	t.Run("corrects bucket versioning config drift", func(t *testing.T) {
+	t.Run("corrects bucket versioning config drift (local is nil)", func(t *testing.T) {
+		td := Setup(t)
+
+		b := createBucket(td)
+		err := td.Kube.Update(td.Ctx, b)
+		td.Require.NoError(err, "update bucket")
+		waitForReconcile(td, b)
+
+		err = td.Minio.SetBucketVersioning(td.Ctx, b.Spec.Name, minio.BucketVersioningConfiguration{
+			Status: "Enabled",
+		})
+		td.Require.NoError(err, "update minio bucket")
+
+		RunOperatorUntil(td, func() error {
+			vc, err := td.Minio.GetBucketVersioning(td.Ctx, b.Spec.Name)
+			if err != nil {
+				return err
+			}
+			if vc.Enabled() {
+				return nil
+			}
+			return StopIteration{}
+		})
+	})
+
+	t.Run("corrects bucket versioning config drift (local is not nil)", func(t *testing.T) {
 		td := Setup(t)
 
 		b := createBucket(td)
@@ -847,11 +871,41 @@ func TestMinioBucket(t *testing.T) {
 		td.Require.True(lc.Rules[0].Expiration.Days == 1)
 	})
 
-	t.Run("corrects bucket lifecycle config drift", func(t *testing.T) {
+	t.Run("corrects bucket lifecycle config drift (local is nil)", func(t *testing.T) {
 		td := Setup(t)
 
 		b := createBucket(td)
+		err := td.Kube.Update(td.Ctx, b)
+		td.Require.NoError(err, "update bucket")
 
+		waitForReconcile(td, b)
+
+		lc := lifecycle.NewConfiguration()
+		lc.Rules = []lifecycle.Rule{{
+			Expiration: lifecycle.Expiration{
+				Days: 1,
+			},
+			Status: "Enabled",
+		}}
+		err = td.Minio.SetBucketLifecycle(td.Ctx, b.Spec.Name, lc)
+		td.Require.NoError(err, "update minio bucket")
+
+		RunOperatorUntil(td, func() error {
+			lc, err := td.Minio.GetBucketLifecycle(td.Ctx, b.Spec.Name)
+			if err != nil {
+				return err
+			}
+			if len(lc.Rules) != 0 {
+				return nil
+			}
+			return StopIteration{}
+		})
+	})
+
+	t.Run("corrects bucket lifecycle config drift (local is not nil)", func(t *testing.T) {
+		td := Setup(t)
+
+		b := createBucket(td)
 		b.Spec.Lifecycle = &v1.MinioBucketLifecycleConfiguration{
 			Rules: []v1.MinioBucketLifecycleRule{{
 				Expiration: v1.MinioBucketLifecycleExpiration{

--- a/internal/operator/minio_bucket_reconciler.go
+++ b/internal/operator/minio_bucket_reconciler.go
@@ -183,10 +183,15 @@ func (r *minioBucketReconciler) Reconcile(ctx context.Context, req reconcile.Req
 			l.Info("bucket versioning configuration changed (status and remote differ)")
 
 			l.Info("set bucket versioning configuration")
-			bvc = minioclient.BucketVersioningConfiguration{}
-			err = convertViaXML(b.Status.CurrentSpec.Versioning, &bvc)
-			if err != nil {
-				return failure(err)
+			// NOTE: if remote has a bucket versioning configuration, by default status must be set to 'Suspended' and overwritten with spec's configuration
+			bvc = minioclient.BucketVersioningConfiguration{
+				Status: "Suspended",
+			}
+			if b.Status.CurrentSpec.Versioning != nil {
+				err = convertViaXML(b.Status.CurrentSpec.Versioning, &bvc)
+				if err != nil {
+					return failure(err)
+				}
 			}
 			err = mtc.SetBucketVersioning(ctx, b.Status.CurrentSpec.Name, bvc)
 			if err != nil {
@@ -197,10 +202,15 @@ func (r *minioBucketReconciler) Reconcile(ctx context.Context, req reconcile.Req
 			l.Info("bucket versioning configuration changed (status and spec differ)")
 
 			l.Info("set bucket versioning configuration")
-			bvc = minioclient.BucketVersioningConfiguration{}
-			err = convertViaXML(b.Spec.Versioning, &bvc)
-			if err != nil {
-				return failure(err)
+			// NOTE: if remote has a bucket versioning configuration, by default status must be set to 'Suspended' and overwritten with spec's configuration
+			bvc = minioclient.BucketVersioningConfiguration{
+				Status: "Suspended",
+			}
+			if b.Spec.Versioning != nil {
+				err = convertViaXML(b.Spec.Versioning, &bvc)
+				if err != nil {
+					return failure(err)
+				}
 			}
 			err = mtc.SetBucketVersioning(ctx, b.Status.CurrentSpec.Name, bvc)
 			if err != nil {
@@ -233,12 +243,14 @@ func (r *minioBucketReconciler) Reconcile(ctx context.Context, req reconcile.Req
 			l.Info("bucket lifecycle configuration changed (status and remote differ)")
 
 			l.Info("set bucket lifecycle configuration")
-			blc = &lifecycle.Configuration{}
-			err = convertViaXML(b.Status.CurrentSpec.Lifecycle, blc)
-			if err != nil {
-				return failure(err)
+			var blc lifecycle.Configuration
+			if b.Status.CurrentSpec.Lifecycle != nil {
+				err = convertViaXML(b.Status.CurrentSpec.Lifecycle, &blc)
+				if err != nil {
+					return failure(err)
+				}
 			}
-			err = mtc.SetBucketLifecycle(ctx, b.Status.CurrentSpec.Name, blc)
+			err = mtc.SetBucketLifecycle(ctx, b.Status.CurrentSpec.Name, &blc)
 			if err != nil {
 				return failure(err)
 			}
@@ -247,12 +259,14 @@ func (r *minioBucketReconciler) Reconcile(ctx context.Context, req reconcile.Req
 			l.Info("bucket lifecycle configuration changed (status and spec differ)")
 
 			l.Info("set bucket lifecycle configuration")
-			blc = &lifecycle.Configuration{}
-			err = convertViaXML(b.Spec.Lifecycle, blc)
-			if err != nil {
-				return failure(err)
+			var blc lifecycle.Configuration
+			if b.Spec.Lifecycle != nil {
+				err = convertViaXML(b.Spec.Lifecycle, &blc)
+				if err != nil {
+					return failure(err)
+				}
 			}
-			err = mtc.SetBucketLifecycle(ctx, b.Status.CurrentSpec.Name, blc)
+			err = mtc.SetBucketLifecycle(ctx, b.Status.CurrentSpec.Name, &blc)
 			if err != nil {
 				return failure(err)
 			}


### PR DESCRIPTION
additionally:
* always enables experimental golang test explorer
* removes duplicate k8s 'errors' import in e2e_tests
* adds unit tests that attempts to (somewhat) capture above issue
* updates testing tenant configuration to expose minio console for additional debugging